### PR TITLE
Introducing Customizable Padding

### DIFF
--- a/Examples/TabsExample/src/App.js
+++ b/Examples/TabsExample/src/App.js
@@ -19,6 +19,36 @@ const posts = [
     id: 3,
     text: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.',
     title: 'de Finibus Bonorum et Malorum 1.10.33'
+  },
+  {
+    id: 4,
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    title: 'Lorem Ipsum'
+  },
+  {
+    id: 5,
+    text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
+    title: 'de Finibus Bonorum et Malorum 1.10.32'
+  },
+  {
+    id: 6,
+    text: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.',
+    title: 'de Finibus Bonorum et Malorum 1.10.33'
+  },
+  {
+    id: 7,
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    title: 'Lorem Ipsum'
+  },
+  {
+    id: 8,
+    text: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
+    title: 'de Finibus Bonorum et Malorum 1.10.32'
+  },
+  {
+    id: 9,
+    text: 'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.',
+    title: 'de Finibus Bonorum et Malorum 1.10.33'
   }
 ];
 /* eslint-enable max-len */
@@ -47,6 +77,7 @@ export default function app() {
       tabsComponentProps={scrollableTabsProps}
       tabs={tabs}
       routeDefs={routeDefs}
+      hiddenPad={50}
     />
   );
 }

--- a/Examples/TabsExample/src/EmptyView.js
+++ b/Examples/TabsExample/src/EmptyView.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { actionCreators } from 'react-native-renavigate';
+
+class EmptyView extends Component {
+
+  backToList = () => {
+    this.props.dispatch(actionCreators.pop());
+  }
+
+  render() {
+    return (
+      <View style={{ marginTop: 60, backgroundColor: 'white' }}>
+        <TouchableOpacity
+          onPress={this.backToList}
+          style={{ margin: 30 }}
+        >
+          <Text style={{ fontWeight: 'bold' }}>Go back to list</Text>
+        </TouchableOpacity>
+        <Text style={{ margin: 30 }}>
+          This view is empty
+        </Text>
+      </View>
+    );
+  }
+}
+
+export default connect()(EmptyView);

--- a/Examples/TabsExample/src/PostDetailContainer.js
+++ b/Examples/TabsExample/src/PostDetailContainer.js
@@ -17,6 +17,10 @@ class PostDetailContainer extends Component {
     this.props.dispatch(actionCreators.pop());
   }
 
+  replaceWithEmpty = () => {
+    this.props.dispatch(actionCreators.replace.EMPTY_VIEW());
+  }
+
   render() {
     return (
       <View style={{ marginTop: 60, backgroundColor: 'white' }}>
@@ -29,6 +33,12 @@ class PostDetailContainer extends Component {
         <Text style={{ margin: 30 }}>
           { this.props.text }
         </Text>
+        <TouchableOpacity
+          onPress={this.replaceWithEmpty}
+          style={{ margin: 30 }}
+        >
+          <Text style={{ fontWeight: 'bold' }}>Go to empty view</Text>
+        </TouchableOpacity>
       </View>
     );
   }

--- a/Examples/TabsExample/src/routes.js
+++ b/Examples/TabsExample/src/routes.js
@@ -4,6 +4,7 @@ import { actionCreators as navigationActions } from 'react-native-renavigate';
 
 import PostDetailContainer from './PostDetailContainer';
 import PostListContainer from './PostListContainer';
+import EmptyView from './EmptyView';
 
 const navButtonStyle = { padding: 5, color: 'blue' };
 const titleStyle = { fontWeight: 'bold' };
@@ -34,6 +35,13 @@ export default {
     params,
     title: () => {
       return <Text style={[titleStyle, navButtonStyle]}>YOUR POSTS</Text>;
+    }
+  }),
+  EMPTY_VIEW: (params) => ({
+    component: EmptyView,
+    params,
+    title: () => {
+      return <Text style={[titleStyle, navButtonStyle]}>EMPTY VIEW</Text>;
     }
   })
 };

--- a/src/RootScene.js
+++ b/src/RootScene.js
@@ -39,6 +39,7 @@ export default class RootScene extends Component {
   componentWillReceiveProps({ activeRoute, navigationMethod, routeStack }) {
 
     this.routeStack = routeStack;
+    this.replaceTriggered = navigationMethod === actions.REPLACE;
 
     if (this.props.activeRoute !== activeRoute) {
       const currentRoute = activeRoute
@@ -78,12 +79,23 @@ export default class RootScene extends Component {
     const navigator = this.getNavigator();
     // Stack diff can be either 0 or 2, but never 1.
     if (
+      !this.replaceTriggered &&
       navigator && this.routeStack && navigator.state.routeStack.length ===
       this.routeStack.length + 1
     ) {
       this.routeStack = null;
+      this.replaceTriggered = false;
       this.props.dispatch(actionCreators.pop());
     }
+  }
+
+  onWillFocus = () => {
+    this.handleRouteChange();
+    return this.props.onWillFocus && this.props.onWillFocus();
+  }
+
+  onDidFocus = () => {
+    return this.props.onDidFocus && this.props.onDidFocus();
   }
 
   render() {
@@ -95,7 +107,8 @@ export default class RootScene extends Component {
       <Navigator
         ref={RootScene.refs.navigatorComponent}
         initialRouteStack={this.initialRouteStack}
-        onWillFocus={this.handleRouteChange}
+        onWillFocus={this.onWillFocus}
+        onDidFocus={this.onDidFocus}
         renderScene={this.renderScene}
         configureScene={this.configureScene}
         navigationBar={this.props.navigationBar(this.props.dispatch, navigationBarProps)}
@@ -125,7 +138,9 @@ RootScene.propTypes = {
   navigationStyles: Navigator.NavigationBar.propTypes.navigationStyles,
   navigationMethod: navigationPropTypes.method,
   routeDefs: React.PropTypes.objectOf(React.PropTypes.func.isRequired).isRequired,
-  routeStack: navigationPropTypes.routeStack
+  routeStack: navigationPropTypes.routeStack,
+  onWillFocus: React.PropTypes.func,
+  onDidFocus: React.PropTypes.func
 };
 
 RootScene.defaultProps = {

--- a/src/RootScene.js
+++ b/src/RootScene.js
@@ -77,7 +77,12 @@ export default class RootScene extends Component {
 
   handleRouteChange = () => {
     const navigator = this.getNavigator();
-    // Stack diff can be either 0 or 2, but never 1.
+    /* Here, we need to whether handle common actions that are captured in the reducer,
+    or to handle swipe-to-pop gesture, typical in iOS.
+    On pop or push, stack diff can be either 0 or 2, respectively.
+    In swipe-to-pop, this diff will be 1, since the action isn't being handled by reducer.
+    Then, if this diff is 1, and the action is not a replace, we need to pop a route from
+    our stack. */
     if (
       !this.replaceTriggered &&
       navigator && this.routeStack && navigator.state.routeStack.length ===

--- a/src/TabsContainer.js
+++ b/src/TabsContainer.js
@@ -15,12 +15,8 @@ class TabsContainer extends Component {
     this.initialTab = props.activeTabIndex || props.initialTab;
     props.dispatch(actionCreators.initTabs(props.tabs.length, this.initialTab));
     this.state = {
-      hiddenPad: 0
+      hiddenPad: this.props.shouldHideTabBar || 0
     };
-  }
-
-  componentWillMount() {
-    this.setState({ hiddenPad: this.props.shouldHideTabBar || 0 });
   }
 
   shouldHideTabBar = () => {

--- a/src/TabsContainer.js
+++ b/src/TabsContainer.js
@@ -24,7 +24,7 @@ class TabsContainer extends Component {
         initialPage={this.initialTab}
         renderTabBar={(props) => {
           if (this.props.shouldHideTabBar && !this.props.alwaysShowTabBar) {
-            return <View />;
+            return <View style={{ height: this.props.hiddenPad || 0 }}/>;
           }
           if (this.props.tabsComponentProps.renderTabBar) {
             return this.props.tabsComponentProps.renderTabBar(props);
@@ -88,6 +88,7 @@ TabsContainer.propTypes = {
   ).isRequired,
   tabsComponentProps: React.PropTypes.shape(ScrollableTabView.propTypes).isRequired,
   alwaysShowTabBar: React.PropTypes.bool,
+  hiddenPad: React.PropTypes.number,
   ...RootScene.propTypes
 };
 

--- a/src/TabsContainer.js
+++ b/src/TabsContainer.js
@@ -15,7 +15,7 @@ class TabsContainer extends Component {
     this.initialTab = props.activeTabIndex || props.initialTab;
     props.dispatch(actionCreators.initTabs(props.tabs.length, this.initialTab));
     this.state = {
-      hiddenPad: this.props.shouldHideTabBar || 0
+      hiddenPad: this.props.hiddenPad || 0
     };
   }
 


### PR DESCRIPTION
### Summary

* Adds additional padding to hiding views with tab bar.
* Removes this padding after view is pushed.
* Fixes replace handling.

### Screenshots

Customizable Padding equals 0:
![customizablewithout](https://cloud.githubusercontent.com/assets/11986709/23080498/bc33ce84-f52f-11e6-8d40-bf7d1b750cf3.gif)

Customizable Padding equals 50:
![handledisappear](https://cloud.githubusercontent.com/assets/11986709/23080595/278fa658-f530-11e6-95e3-430b6bee6473.gif)


Replace action fix (a detail is being replaced by an empty view):
![handlereplace](https://cloud.githubusercontent.com/assets/11986709/23080527/d2b679c2-f52f-11e6-94e0-f2fcee215bd8.gif)

### Known Issues

* If the view being pushed is too large, the resultant effect may not be intuitive (see Customizable Padding equals 50 gif)
* Swipe to pop overrides pad-hiding behavior
