### PR TITLE
Fixing swipe to pop behavior

### DIFF
--- a/src/RootScene.js
+++ b/src/RootScene.js
@@ -83,15 +83,17 @@ export default class RootScene extends Component {
     In swipe-to-pop, this diff will be 1, since the action isn't being handled by reducer.
     Then, if this diff is 1, and the action is not a replace, we need to pop a route from
     our stack. */
+
     if (
       !this.replaceTriggered &&
       navigator && this.routeStack && navigator.state.routeStack.length ===
       this.routeStack.length + 1
     ) {
       this.routeStack = null;
-      this.replaceTriggered = false;
-      this.props.dispatch(actionCreators.pop());
+      this.props.dispatch(actionCreators.softPop());
     }
+
+    this.replaceTriggered = false;
   }
 
   onWillFocus = () => {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,7 @@
 
 export const actions = {
   PUSH: 'push',
+  SOFT_POP: 'softPop',
   POP: 'pop',
   POP_TO_TOP: 'popToTop',
   RESET_TO: 'resetTo',
@@ -13,6 +14,7 @@ export const actionCreators = {
   push: {},
   resetTo: {},
   replace: {},
+  softPop: () => ({ type: actions.SOFT_POP }),
   pop: () => ({ type: actions.POP }),
   popToTop: () => ({ type: actions.POP_TO_TOP }),
   tabChanged: (tabIndex) => ({ type: actions.TAB_CHANGED, payload: { tabIndex } }),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -46,6 +46,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         }
       });
     }
+    case actions.SOFT_POP:
     case actions.POP: {
       const tabState = state[state.activeTabIndex];
       const nextActiveRoute = tabState.routeStack.length > 0


### PR DESCRIPTION
## Summary

* Fixes double pop behavior when a view is pushed from a pushed view.
* Updates `replaceTriggered` flag, so after a replace allows to TabBar to appear if a swipe to pop is triggered.

## Screenshots

Tested on Utility

![swipefix](https://cloud.githubusercontent.com/assets/11986709/23799967/3e5bd3f2-0589-11e7-860b-0fc7ddd2344f.gif)
