### PR TITLE
Fix for a border case for routeStack handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-renavigate",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "React native navigation made easy using redux",
   "main": "lib/index.js",
   "scripts": {

--- a/src/RootScene.js
+++ b/src/RootScene.js
@@ -39,7 +39,7 @@ export default class RootScene extends Component {
   componentWillReceiveProps({ activeRoute, navigationMethod, routeStack }) {
 
     this.routeStack = routeStack;
-    this.replaceTriggered = navigationMethod === actions.REPLACE;
+    this.nonPopActionTriggered = navigationMethod === actions.REPLACE || navigationMethod === actions.PUSH;
 
     if (this.props.activeRoute !== activeRoute) {
       const currentRoute = activeRoute
@@ -85,7 +85,7 @@ export default class RootScene extends Component {
     our stack. */
 
     if (
-      !this.replaceTriggered &&
+      !this.nonPopActionTriggered &&
       navigator && this.routeStack && navigator.state.routeStack.length ===
       this.routeStack.length + 1
     ) {
@@ -93,7 +93,7 @@ export default class RootScene extends Component {
       this.props.dispatch(actionCreators.softPop());
     }
 
-    this.replaceTriggered = false;
+    this.nonPopActionTriggered = false;
   }
 
   onWillFocus = () => {

--- a/src/RootScene.js
+++ b/src/RootScene.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Navigator } from 'react-native';
 
-import { initActions, actions, actionCreators } from './actions';
+import { initActions, methodActions, actionCreators } from './actions';
 import { propTypes as navigationPropTypes } from './reducer';
 import navigationBarRouteMapper from './navigationBarRouteMapper';
 
@@ -39,7 +39,8 @@ export default class RootScene extends Component {
   componentWillReceiveProps({ activeRoute, navigationMethod, routeStack }) {
 
     this.routeStack = routeStack;
-    this.nonPopActionTriggered = navigationMethod === actions.REPLACE || navigationMethod === actions.PUSH;
+    this.nonPopActionTriggered =
+      navigationMethod === methodActions.REPLACE || navigationMethod === methodActions.PUSH;
 
     if (this.props.activeRoute !== activeRoute) {
       const currentRoute = activeRoute
@@ -48,11 +49,11 @@ export default class RootScene extends Component {
       this.setState({ currentRoute });
 
       const navigator = this.getNavigator();
-      if (navigationMethod === actions.POP || navigationMethod === actions.POP_TO_TOP) {
+      if (navigationMethod === methodActions.POP || navigationMethod === methodActions.POP_TO_TOP) {
         navigator[navigationMethod]();
-      } else if (navigationMethod === actions.PUSH ||
-                 navigationMethod === actions.RESET_TO ||
-                 navigationMethod === actions.REPLACE) {
+      } else if (navigationMethod === methodActions.PUSH ||
+                 navigationMethod === methodActions.RESET_TO ||
+                 navigationMethod === methodActions.REPLACE) {
         navigator[navigationMethod](currentRoute);
       }
     }

--- a/src/actions.js
+++ b/src/actions.js
@@ -10,6 +10,28 @@ export const actions = {
   INIT_TABS: '@@renavigate/INIT_TABS'
 };
 
+export const methodActions = {
+  PUSH: 'push',
+  SOFT_POP: 'softPop',
+  POP: 'pop',
+  POP_TO_TOP: 'popToTop',
+  RESET_TO: 'resetTo',
+  REPLACE: 'replace',
+  TAB_CHANGED: 'tabChanged',
+  INIT_TABS: 'initTabs'
+};
+
+export const typeToMethod = {
+  '@@renavigate/PUSH': 'push',
+  '@@renavigate/SOFT_POP': 'softPop',
+  '@@renavigate/POP': 'pop',
+  '@@renavigate/POP_TO_TOP': 'popToTop',
+  '@@renavigate/RESET_TO': 'resetTo',
+  '@@renavigate/REPLACE': 'replace',
+  '@@renavigate/TAB_CHANGED': 'tabChanged',
+  '@@renavigate/INIT_TABS': 'initTabs'
+};
+
 export const actionCreators = {
   push: {},
   resetTo: {},

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,13 +1,13 @@
 
 export const actions = {
-  PUSH: 'push',
-  SOFT_POP: 'softPop',
-  POP: 'pop',
-  POP_TO_TOP: 'popToTop',
-  RESET_TO: 'resetTo',
-  REPLACE: 'replace',
-  TAB_CHANGED: 'tabChanged',
-  INIT_TABS: 'initTabs'
+  PUSH: '@@renavigate/PUSH',
+  SOFT_POP: '@@renavigate/SOFT_POP',
+  POP: '@@renavigate/POP',
+  POP_TO_TOP: '@@renavigate/POP_TO_TOP',
+  RESET_TO: '@@renavigate/RESET_TO',
+  REPLACE: '@@renavigate/REPLACE',
+  TAB_CHANGED: '@@renavigate/TAB_CHANGED',
+  INIT_TABS: '@@renavigate/INIT_TABS'
 };
 
 export const actionCreators = {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Immutable from 'seamless-immutable';
 
-import { actions } from './actions';
+import { actions, typeToMethod } from './actions';
 
 export const defaultState = Immutable({
   activeTabIndex: null,
@@ -22,7 +22,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         [state.activeTabIndex]: {
           routeStack: [...tabState.routeStack, tabState.activeRoute],
           activeRoute: payload.route,
-          method: type
+          method: typeToMethod[type]
         },
         shouldHideTabBar: true
       });
@@ -32,7 +32,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         [state.activeTabIndex]: {
           routeStack: [],
           activeRoute: payload.route,
-          method: type
+          method: typeToMethod[type]
         },
         shouldHideTabBar: false
       });
@@ -42,7 +42,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         [state.activeTabIndex]: {
           ...state[state.activeTabIndex],
           activeRoute: payload.route,
-          method: type
+          method: typeToMethod[type]
         }
       });
     }
@@ -56,7 +56,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         [state.activeTabIndex]: {
           routeStack: tabState.routeStack.slice(0, -1),
           activeRoute: nextActiveRoute,
-          method: type
+          method: typeToMethod[type]
         },
         shouldHideTabBar: tabState.routeStack.slice(0, -1).length > 0
       });
@@ -67,7 +67,7 @@ export default function reducer(state = defaultState, { type, payload }) {
         [state.activeTabIndex]: {
           routeStack: [],
           activeRoute: tabState.routeStack.length > 0 ? tabState.routeStack[0] : tabState.activeRoute,
-          method: type
+          method: typeToMethod[type]
         },
         shouldHideTabBar: false
       });

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,5 +1,5 @@
 import reducer, { defaultState } from '../src/reducer';
-import { actionCreators, initActions } from '../src/actions';
+import { actions, actionCreators, initActions } from '../src/actions';
 
 describe('#reducer', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: 'push',
+            method: actions.PUSH,
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -46,7 +46,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: 'resetTo',
+            method: actions.RESET_TO,
             routeStack: []
           },
           shouldHideTabBar: false
@@ -61,7 +61,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: 'replace',
+            method: actions.REPLACE,
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -79,7 +79,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: activeRouteBeforeAction,
-            method: 'pop',
+            method: actions.POP,
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -97,7 +97,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: activeRouteBeforeAction,
-            method: 'popToTop',
+            method: actions.POP_TO_TOP,
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -123,7 +123,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: 'push',
+            method: actions.PUSH,
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -137,7 +137,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: 'resetTo',
+            method: actions.RESET_TO,
             routeStack: []
           },
           shouldHideTabBar: false
@@ -154,7 +154,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: 'replace',
+            method: actions.REPLACE,
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: true
@@ -170,7 +170,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-1)[0],
-            method: 'pop',
+            method: actions.POP,
             routeStack: routeStackBeforeAction.slice(0, -1)
           },
           shouldHideTabBar: false
@@ -187,7 +187,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction[0],
-            method: 'popToTop',
+            method: actions.POP_TO_TOP,
             routeStack: []
           },
           shouldHideTabBar: false
@@ -221,7 +221,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: 'push',
+            method: actions.PUSH,
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -235,7 +235,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: 'resetTo',
+            method: actions.RESET_TO,
             routeStack: []
           },
           shouldHideTabBar: false
@@ -252,7 +252,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: 'replace',
+            method: actions.REPLACE,
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: true
@@ -268,7 +268,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-1)[0],
-            method: 'pop',
+            method: actions.POP,
             routeStack: routeStackBeforeAction.slice(0, -1)
           },
           shouldHideTabBar: true
@@ -285,7 +285,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-4)[0],
-            method: 'pop',
+            method: actions.POP,
             routeStack: routeStackBeforeAction.slice(0, -4)
           },
           shouldHideTabBar: true
@@ -306,7 +306,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction[0],
-            method: 'popToTop',
+            method: actions.POP_TO_TOP,
             routeStack: []
           },
           shouldHideTabBar: false

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,5 +1,5 @@
 import reducer, { defaultState } from '../src/reducer';
-import { actions, actionCreators, initActions } from '../src/actions';
+import { actionCreators, initActions } from '../src/actions';
 
 describe('#reducer', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: actions.PUSH,
+            method: 'push',
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -46,7 +46,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: actions.RESET_TO,
+            method: 'resetTo',
             routeStack: []
           },
           shouldHideTabBar: false
@@ -61,7 +61,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: actions.REPLACE,
+            method: 'replace',
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -79,7 +79,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: activeRouteBeforeAction,
-            method: actions.POP,
+            method: 'pop',
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -97,7 +97,7 @@ describe('#reducer', () => {
         const expectedState = defaultState.merge({
           [defaultState.activeTabIndex]: {
             activeRoute: activeRouteBeforeAction,
-            method: actions.POP_TO_TOP,
+            method: 'popToTop',
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: false
@@ -123,7 +123,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: actions.PUSH,
+            method: 'push',
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -137,7 +137,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: actions.RESET_TO,
+            method: 'resetTo',
             routeStack: []
           },
           shouldHideTabBar: false
@@ -154,7 +154,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: actions.REPLACE,
+            method: 'replace',
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: true
@@ -170,7 +170,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-1)[0],
-            method: actions.POP,
+            method: 'pop',
             routeStack: routeStackBeforeAction.slice(0, -1)
           },
           shouldHideTabBar: false
@@ -187,7 +187,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction[0],
-            method: actions.POP_TO_TOP,
+            method: 'popToTop',
             routeStack: []
           },
           shouldHideTabBar: false
@@ -221,7 +221,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: actions.PUSH,
+            method: 'push',
             routeStack: routeStackBeforeAction.concat(activeRouteBeforeAction)
           },
           shouldHideTabBar: true
@@ -235,7 +235,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 1 } },
-            method: actions.RESET_TO,
+            method: 'resetTo',
             routeStack: []
           },
           shouldHideTabBar: false
@@ -252,7 +252,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: { name: 'ROUTE_A', params: { routeParam: 4 } },
-            method: actions.REPLACE,
+            method: 'replace',
             routeStack: routeStackBeforeAction
           },
           shouldHideTabBar: true
@@ -268,7 +268,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-1)[0],
-            method: actions.POP,
+            method: 'pop',
             routeStack: routeStackBeforeAction.slice(0, -1)
           },
           shouldHideTabBar: true
@@ -285,7 +285,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction.slice(-4)[0],
-            method: actions.POP,
+            method: 'pop',
             routeStack: routeStackBeforeAction.slice(0, -4)
           },
           shouldHideTabBar: true
@@ -306,7 +306,7 @@ describe('#reducer', () => {
         const expectedState = initialSpecState.merge({
           [initialSpecState.activeTabIndex]: {
             activeRoute: routeStackBeforeAction[0],
-            method: actions.POP_TO_TOP,
+            method: 'popToTop',
             routeStack: []
           },
           shouldHideTabBar: false


### PR DESCRIPTION
### Summary

* Fixes a border case, when app comes from background after a `resetTo` action.
* Renames actions' names

### Screens

After:
![renavigatebefore](https://cloud.githubusercontent.com/assets/11986709/24099858/2dbb73bc-0d50-11e7-9fc0-1fcf35ed7385.gif)

Before:
![renavigatebeforebefore](https://cloud.githubusercontent.com/assets/11986709/24099859/2dbc7406-0d50-11e7-89a6-614fa7042b3c.gif)
